### PR TITLE
Added printerDrivers dictionary with basic example printer names and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Add-Printer-via-CUPS
 Bash script for adding a printer via cups for MacOS devices
 
+1. Select the printer driver you want.
+2. Install the printer driver.
+
 ## **Goal's of the Project**
   - Accept short option *-s, -p, -d*
   - Accept Long option versions as well *--server, --printer, --driver*
@@ -12,3 +15,5 @@ Bash script for adding a printer via cups for MacOS devices
   - Become more familiar with Bash
   - Learn specified option flags coding
   
+
+


### PR DESCRIPTION
Reference printerDrivers dict in select_driver() function if driver argument is undefined
> Set the driver to the found value

Add [STATUS] to info commands, cleanup status text

Utilize ZSH for associative arrays
> Example `zsh add_printers.sh -s "example" -p T802-PS-C01`